### PR TITLE
Refactor `Mixin#[]`

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -95,17 +95,7 @@ module Dry
       def resolve(key)
         config.resolver.call(_container, key)
       end
-      # Resolve an item from the container
-      #
-      # @param [Mixed] key
-      #   The key for the item you wish to resolve
-      #
-      # @return [Mixed]
-      #
-      # @api public
-      def [](key)
-        resolve(key)
-      end
+      alias_method :[], :resolve
     end
   end
 end


### PR DESCRIPTION
Used `alias_method` to remove duplication in docs. (Yard ever since `0.8.0` knows how to document alias methods using docs from corresponding aliased methods).
