### PR TITLE
Adding keys method

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -132,6 +132,15 @@ module Dry
         config.resolver.key?(_container, key)
       end
 
+      # An array of registered names for the container
+      #
+      # @return [Array<String>]
+      #
+      # @api public
+      def keys
+        config.resolver.keys(_container)
+      end
+
       # Evaluate block and register items in namespace
       #
       # @param [Mixed] namespace

--- a/lib/dry/container/registry.rb
+++ b/lib/dry/container/registry.rb
@@ -31,7 +31,7 @@ module Dry
         key = key.to_s.dup.freeze
         @_mutex.synchronize do
           if container.key?(key)
-            fail Error, "There is already an item registered with the key #{key.inspect}"
+            raise Error, "There is already an item registered with the key #{key.inspect}"
           end
 
           container[key] = ::Dry::Container::Item.new(item, options)

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -38,6 +38,15 @@ module Dry
       def key?(container, key)
         container.key?(key.to_s)
       end
+
+      # An array of registered names for the container
+      #
+      # @return [Array]
+      #
+      # @api public
+      def keys(container)
+        container.keys
+      end
     end
   end
 end

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -19,7 +19,7 @@ module Dry
       # @api public
       def call(container, key)
         item = container.fetch(key.to_s) do
-          fail Error, "Nothing registered with the key #{key.inspect}"
+          raise Error, "Nothing registered with the key #{key.inspect}"
         end
 
         item.call

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -116,6 +116,7 @@ shared_examples 'a container' do
           it 'registers and resolves an object' do
             container.register(:item) { 'item' }
 
+            expect(container.keys).to eq(['item'])
             expect(container.key?(:item)).to be true
             expect(container.resolve(:item)).to eq('item')
           end
@@ -134,6 +135,7 @@ shared_examples 'a container' do
         it 'registers and resolves a proc' do
           container.register(:item, call: false) { 'item' }
 
+          expect(container.keys).to eq(['item'])
           expect(container.key?(:item)).to be true
           expect(container.resolve(:item).call).to eq('item')
           expect(container[:item].call).to eq('item')
@@ -147,6 +149,7 @@ shared_examples 'a container' do
           it 'registers and resolves an object' do
             container.register(:item, proc { 'item' })
 
+            expect(container.keys).to eq(['item'])
             expect(container.key?(:item)).to be true
             expect(container.resolve(:item)).to eq('item')
             expect(container[:item]).to eq('item')
@@ -157,6 +160,7 @@ shared_examples 'a container' do
           it 'registers and resolves a proc' do
             container.register(:item, proc { |item| item })
 
+            expect(container.keys).to eq(['item'])
             expect(container.key?(:item)).to be true
             expect(container.resolve(:item).call('item')).to eq('item')
             expect(container[:item].call('item')).to eq('item')
@@ -168,6 +172,7 @@ shared_examples 'a container' do
         it 'registers and resolves a proc' do
           container.register(:item, proc { 'item' }, call: false)
 
+          expect(container.keys).to eq(['item'])
           expect(container.key?(:item)).to be true
           expect(container.resolve(:item).call).to eq('item')
           expect(container[:item].call).to eq('item')
@@ -181,6 +186,7 @@ shared_examples 'a container' do
           item = 'item'
           container.register(:item, item)
 
+          expect(container.keys).to eq(['item'])
           expect(container.key?(:item)).to be true
           expect(container.resolve(:item)).to be(item)
           expect(container[:item]).to be(item)
@@ -192,6 +198,7 @@ shared_examples 'a container' do
           item = -> { 'test' }
           container.register(:item, item, call: false)
 
+          expect(container.keys).to eq(['item'])
           expect(container.key?(:item)).to be true
           expect(container.resolve(:item)).to eq(item)
           expect(container[:item]).to eq(item)


### PR DESCRIPTION
## Adding Resolver#keys method

@906c0febd568f8d50260552a11cc9b03cfbe18c7

Given that the Resolver#key? method existed, I'm adding a mechanism to
inspect the container. I envision that this inspection is helpful from
a configuration validation and visualization stand-point. I am looking
to assert that my container has a handful of registrations so I can
begin writing further interface documentation for those dependencies.

Closes #12
## Switching from fail to raise

@a59553e71a8f3f663c1e58368c566115ee41f024

As of Rubocop 0.38.0 raise is preferred over fail (see
bbatsov/rubocop#2732 for more discussion). So this commit brings
dry-container in line with the "standard" style enforcement of
Rubocop.
