### PR TITLE
Adding a Brief Example to Synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ A simple, configurable container implemented in Ruby
 
 ## Synopsis
 
+### Brief Example
+
+```ruby
+container = Dry::Container.new
+container.register(:parrot) { |a| puts a }
+
+parrot = container.resolve(:parrot)
+parrot.call("Hello World")
+# Hello World
+# => nil
+```
+
+### Detailed Example
+
 ```ruby
 User = Struct.new(:name, :email)
 


### PR DESCRIPTION
The existing Synopsis is a lot to read and comprehend. The brief
example is there to provide an at a glance answer to the questions:

> Would this be useful for me?
> What does this do?

[skip ci]
