### PR TITLE
Allow access to stubbed keys via the [] method.

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -105,7 +105,19 @@ module Dry
       def resolve(key)
         config.resolver.call(_container, key)
       end
-      alias [] resolve
+
+      # Resolve an item from the container
+      #
+      # @param [Mixed] key
+      #   The key for the item you wish to resolve
+      #
+      # @return [Mixed]
+      #
+      # @api public
+      # @see Dry::Container::Mixin#resolve
+      def [](key)
+        resolve(key)
+      end
 
       # Merge in the items of the other container
       #

--- a/lib/dry/container/stub.rb
+++ b/lib/dry/container/stub.rb
@@ -7,7 +7,6 @@ module Dry
       def resolve(key)
         _stubs.fetch(key) { super }
       end
-      alias [] resolve
 
       # Add a stub to the container
       def stub(key, value, &block)

--- a/lib/dry/container/stub.rb
+++ b/lib/dry/container/stub.rb
@@ -7,6 +7,7 @@ module Dry
       def resolve(key)
         _stubs.fetch(key) { super }
       end
+      alias [] resolve
 
       # Add a stub to the container
       def stub(key, value, &block)

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -329,11 +329,13 @@ shared_examples 'a container' do
     it 'keys can be stubbed' do
       container.stub(:item, 'stub')
       expect(container.resolve(:item)).to eql('stub')
+      expect(container[:item]).to eql('stub')
     end
 
     it 'only other keys remain accesible' do
       container.stub(:item, 'stub')
       expect(container.resolve(:foo)).to eql('bar')
+      expect(container[:foo]).to eql('bar')
     end
 
     it 'keys can be reverted back to their original value' do
@@ -341,6 +343,7 @@ shared_examples 'a container' do
       container.unstub(:item)
 
       expect(container.resolve(:item)).to eql('item')
+      expect(container[:item]).to eql('item')
     end
 
     describe 'with block argument' do


### PR DESCRIPTION
When using stubs, resolving `:item` via `container.resolve(:item)` returns the stub. 

The small change included here ensures that `container[:item]` returns the stub as well.
