### PR TITLE
Move inherited hook into a module

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -26,19 +26,22 @@ module Dry
     module Mixin
       # @private
       def self.extended(base)
+        hooks_mod = Module.new do
+          def inherited(subclass)
+            subclass.instance_variable_set(:@_container, @_container.dup)
+            super
+          end
+        end
+
         base.class_eval do
           extend ::Dry::Configurable
+          extend hooks_mod
 
           setting :registry, ::Dry::Container::Registry.new
           setting :resolver, ::Dry::Container::Resolver.new
           setting :namespace_separator, '.'
 
           @_container = ::Concurrent::Hash.new
-
-          def self.inherited(subclass)
-            subclass.instance_variable_set(:@_container, @_container.dup)
-            super
-          end
         end
       end
 


### PR DESCRIPTION
This is necessary to allow a class that extends `Dry::Container::Mixin` to have its _own_ `.inherited` hook (which would otherwise just completely overwrite the `.inherited` defined here).

For more background: I'm in the process of adding a `.inherited` method to `Dry::Component::Container`, which extends `Dry::Container::Mixin`. Without this change, all the regular container behaviour was broken in any subclasses of `Dry::Component::Container` because its own `.inherited` method was blowing away the one defined by `Dry::Container::Mixin`.

@AMHOL – you OK with this change?
