### PR TITLE
Ruby minimum version 2.0

### DIFF
--- a/dry-container.gemspec
+++ b/dry-container.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = ">= 2.0.0"
+
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1', '>= 0.1.3'
 


### PR DESCRIPTION
```
root@16f23857ddee:/app# ruby -v
ruby 1.9.3p545 (2014-02-24 revision 45159) [x86_64-linux]

root@16f23857ddee:/app# bundle exec ruby -e 'require "dry-container"'
/app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry/container.rb:9:in `require': /app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry/container/mixin.rb:132: syntax error, unexpected tLABEL (SyntaxError)
      def merge(other, namespace: nil)
                                 ^
/app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry/container/mixin.rb:213: syntax error, unexpected keyword_end, expecting $end
        from /app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry/container.rb:9:in `<top (required)>'
        from /app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry-container.rb:1:in `require'
        from /app/ruby/1.9.1/gems/dry-container-0.4.0/lib/dry-container.rb:1:in `<top (required)>'
        from -e:1:in `require'
        from -e:1:in `<main>'
```
