### PR TITLE
Allow items to be initialized lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ end
 container.import(ns)
 container.resolve('repositories.authentication.users')
 # => []
+
+# You can also register a block that is used to initialize a dependency and
+# then memoize it, allowing several dependencies to be added without
+# enforcing an instantiation order
+class MessagePrinter
+  def initialize(container)
+    @message = container.resolve(:message)
+    @time = Time.now
+  end
+
+  def print
+    puts "#{@message} at #{@time}"
+  end
+end
+
+container.register(:message_printer, -> { MessagePrinter.new(container) }, memoize: true)
+container.register(:message, "Hello, world!")
+container.resolve(:message_printer).print
+# => Hello, world! at 2016-08-30 05:32:12 -0700
+
+# Same instance is reused next time
+container.resolve(:message_printer).print
+# => Hello, world! at 2016-08-30 05:32:12 -0700
 ```
 
 You can also get container behaviour at both the class and instance level via the mixin:

--- a/lib/dry/container/item.rb
+++ b/lib/dry/container/item.rb
@@ -4,20 +4,30 @@ module Dry
     #
     # @private
     class Item
-      attr_reader :item, :options
+      attr_reader :item, :options, :memoize, :memoize_mutex
 
       def initialize(item, options = {})
         @item = item
         @options = {
           call: item.is_a?(::Proc) && item.parameters.empty?
         }.merge(options)
+        @memoize = item.is_a?(::Proc) && options[:memoize] == true
+        @memoize_mutex = Mutex.new if memoize
       end
 
       def call
+        return memoized_item if memoize
+
         if options[:call] == true
           item.call
         else
           item
+        end
+      end
+
+      def memoized_item
+        memoize_mutex.synchronize do
+          @memoized_item ||= item.call
         end
       end
     end

--- a/lib/dry/container/item.rb
+++ b/lib/dry/container/item.rb
@@ -29,6 +29,8 @@ module Dry
         end
       end
 
+      private
+
       def memoized_item
         memoize_mutex.synchronize do
           @memoized_item ||= item.call

--- a/lib/dry/container/item.rb
+++ b/lib/dry/container/item.rb
@@ -11,8 +11,12 @@ module Dry
         @options = {
           call: item.is_a?(::Proc) && item.parameters.empty?
         }.merge(options)
-        @memoize = item.is_a?(::Proc) && options[:memoize] == true
-        @memoize_mutex = Mutex.new if memoize
+
+        if options[:memoize] == true
+          raise Error, "Memoize only supported for a block or a proc" unless item.is_a?(::Proc)
+          @memoize = true
+          @memoize_mutex = Mutex.new
+        end
       end
 
       def call

--- a/lib/dry/container/registry.rb
+++ b/lib/dry/container/registry.rb
@@ -21,7 +21,7 @@ module Dry
       # @option options [Symbol] :call
       #   Whether the item should be called when resolved
       #
-      # @raise [Dry::Conainer::Error]
+      # @raise [Dry::Container::Error]
       #   If an item is already registered with the given key
       #
       # @return [Mixed]

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -204,6 +204,12 @@ shared_examples 'a container' do
           expect(container.resolve(:item)).to be 1
           expect(container.resolve(:item)).to be 1
         end
+
+        context 'when receiving something other than a proc' do
+          it do
+            expect { container.register(:item, "Hello!", memoize: true) }.to raise_error(Dry::Container::Error)
+          end
+        end
       end
     end
 

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -185,6 +185,26 @@ shared_examples 'a container' do
           expect(container[:item].call).to eq('item')
         end
       end
+
+      context 'with option memoize: true' do
+        it 'registers and resolves a proc' do
+          container.register(:item, proc { 'item' }, memoize: true)
+
+          expect(container.keys).to eq(['item'])
+          expect(container.key?(:item)).to be true
+          expect(container.resolve(:item)).to eq('item')
+          expect(container[:item]).to eq('item')
+        end
+
+        it 'only resolves the proc once' do
+          resolved_times = 0
+
+          container.register(:item, proc { resolved_times += 1 }, memoize: true)
+
+          expect(container.resolve(:item)).to be 1
+          expect(container.resolve(:item)).to be 1
+        end
+      end
     end
 
     describe 'registering an object' do

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -190,6 +190,7 @@ shared_examples 'a container' do
         it 'registers and resolves a proc' do
           container.register(:item, proc { 'item' }, memoize: true)
 
+          expect(container[:item]).to be container[:item]
           expect(container.keys).to eq(['item'])
           expect(container.key?(:item)).to be true
           expect(container.resolve(:item)).to eq('item')


### PR DESCRIPTION
This commits adds a `:lazy` option to items. A lazy item initialized with a proc (or block) will call the proc only to get the value once, and will then reuse the item on further calls.

The main usage of this is allowing a number of dependencies to be registered in the container without caring about their order (e.g. when a dependency depends on another), but still reusing the same objects, avoiding the need to instance them on each call to resolve, as is the default when not using lazy.

Hope this is acceptable, and thanks for your awesome work on dry-container!
