### PR TITLE
Adding `Dry::Container::Mixin#each`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## Added
+
+* `Dry::Container::Mixin#each` - provides a means of seeing what all is registered in the container ([jeremyf](https://github.com/jeremyf))
+
 ## v0.5.0
 
 ## Added

--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -183,6 +183,21 @@ module Dry
         self
       end
 
+      # Calls block once for each key/value pair in the container, passing the key and the registered item parameters.
+      #
+      # If no block is given, an enumerator is returned instead.
+      #
+      # @return [Enumerator]
+      #
+      # @api public
+      #
+      # @note In discussions with other developers, it was felt that being able to iterate over not just
+      #       the registered keys, but to see what was registered would be very helpful. This is a step
+      #       toward doing that.
+      def each(&block)
+        config.resolver.each(_container, &block)
+      end
+
       # Evaluate block and register items in namespace
       #
       # @param [Mixed] namespace

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -59,6 +59,20 @@ module Dry
       def each_key(container, &block)
         container.each_key(&block)
       end
+
+      # Calls block once for each key in container, passing the key and the registered item parameters.
+      #
+      # If no block is given, an enumerator is returned instead.
+      #
+      # @return Key, Value
+      #
+      # @api public
+      # @note In discussions with other developers, it was felt that being able to iterate over not just
+      #       the registered keys, but to see what was registered would be very helpful. This is a step
+      #       toward doing that.
+      def each(container, &block)
+        container.each(&block)
+      end
     end
   end
 end

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -359,6 +359,30 @@ RSpec.shared_examples 'a container' do
       end
     end
 
+    describe '#each' do
+      let(:keys) { [:key_1, :key_2] }
+      let(:expected_key_value_pairs) { [['key_1', kind_of(Dry::Container::Item)], ['key_2', kind_of(Dry::Container::Item)]] }
+      let!(:yielded_key_value_pairs) { [] }
+
+      before do
+        keys.each do |key|
+          container.register(key) { "value_for_#{key}" }
+        end
+      end
+
+      subject! do
+        container.each { |key, value| yielded_key_value_pairs << [key, value] }
+      end
+
+      it 'yields stringified versions of all registered keys to the block' do
+        expect(yielded_key_value_pairs).to match_array(expected_key_value_pairs)
+      end
+
+      it 'returns the container' do
+        is_expected.to eq(container)
+      end
+    end
+
     describe 'namespace' do
       context 'when block does not take arguments' do
         before do


### PR DESCRIPTION
In discussions with other developers, it was felt that being able to
iterate over not just the registered keys, but to see what was
registered would be very helpful. This is a step toward doing that.