### PR TITLE
Use .new instead of inheritance to create Error class

### DIFF
--- a/lib/dry/container/error.rb
+++ b/lib/dry/container/error.rb
@@ -1,6 +1,6 @@
 module Dry
   class Container
     # @api public
-    class Error < ::StandardError; end
+    Error = Class.new(StandardError)
   end
 end


### PR DESCRIPTION
I've just noticed that Error class in container used inheritance, instead of Class.new -> https://github.com/dry-rb/dry-system/blob/master/lib/dry/system/errors.rb#L7

I think it would be nice to be consistent and to follow one rule. In my opinion - Class.new is preferable way.