### PR TITLE
Remove dry-configurable dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,13 @@ script:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.1
-  - rbx-3
-  - jruby-9.1.5.0
-  - ruby-head
-  - jruby-head
+  - 2.3.4
+  - 2.4.1
+  - jruby-9.1.9.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
     - COVERAGE='true'
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
 notifications:
   email: false
   webhooks:

--- a/dry-container.gemspec
+++ b/dry-container.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'dry-core', '~> 0.4.2'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/dry-container.gemspec
+++ b/dry-container.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'dry-configurable', '~> 0.1', '>= 0.1.3'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/container.rb
+++ b/lib/dry/container.rb
@@ -1,5 +1,5 @@
 require 'concurrent'
-require 'dry-configurable'
+require 'dry/core/class_attributes'
 require 'dry/container/error'
 require 'dry/container/item/base'
 require 'dry/container/item/memoizable'

--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -73,6 +73,18 @@ module Dry
           registry ::Dry::Container::Registry.new
           resolver ::Dry::Container::Resolver.new
           namespace_separator '.'
+
+          def registry
+            self.class.registry
+          end
+
+          def resolver
+            self.class.resolver
+          end
+
+          def namespace_separator
+            self.class.namespace_separator
+          end
         end
       end
 
@@ -99,7 +111,7 @@ module Dry
           item = contents
         end
 
-        _registry.call(_container, key, item, options)
+        registry.call(_container, key, item, options)
 
         self
       end
@@ -113,7 +125,7 @@ module Dry
       #
       # @api public
       def resolve(key)
-        _resolver.call(_container, key)
+        resolver.call(_container, key)
       end
 
       # Resolve an item from the container
@@ -144,7 +156,7 @@ module Dry
         if namespace
           _container.merge!(
             other._container.each_with_object(::Concurrent::Hash.new) do |a, h|
-              h[PREFIX_NAMESPACE.call(namespace, a.first, _namespace_separator)] = a.last
+              h[PREFIX_NAMESPACE.call(namespace, a.first, namespace_separator)] = a.last
             end
           )
         else
@@ -163,7 +175,7 @@ module Dry
       #
       # @api public
       def key?(key)
-        _resolver.key?(_container, key)
+        resolver.key?(_container, key)
       end
 
       # An array of registered names for the container
@@ -172,7 +184,7 @@ module Dry
       #
       # @api public
       def keys
-        _resolver.keys(_container)
+        resolver.keys(_container)
       end
 
       # Calls block once for each key in container, passing the key as a parameter.
@@ -183,7 +195,7 @@ module Dry
       #
       # @api public
       def each_key(&block)
-        _resolver.each_key(_container, &block)
+        resolver.each_key(_container, &block)
         self
       end
 
@@ -199,7 +211,7 @@ module Dry
       #       the registered keys, but to see what was registered would be very helpful. This is a step
       #       toward doing that.
       def each(&block)
-        _resolver.each(_container, &block)
+        resolver.each(_container, &block)
       end
 
       # Evaluate block and register items in namespace
@@ -214,7 +226,7 @@ module Dry
         ::Dry::Container::NamespaceDSL.new(
           self,
           namespace,
-          _namespace_separator,
+          namespace_separator,
           &block
         )
 
@@ -238,18 +250,6 @@ module Dry
       # @private no, really
       def _container
         @_container
-      end
-
-      def _registry
-        respond_to?(:registry) ? registry : self.class.registry
-      end
-
-      def _resolver
-        respond_to?(:resolver) ? resolver : self.class.resolver
-      end
-
-      def _namespace_separator
-        respond_to?(:namespace_separator) ? namespace_separator : self.class.namespace_separator
       end
     end
   end

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'a container' do
   describe 'configuration' do
     describe 'registry' do
       describe 'default' do
-        it { expect(klass.config.registry).to be_a(Dry::Container::Registry) }
+        it { expect(klass.registry).to be_a(Dry::Container::Registry) }
       end
 
       describe 'custom' do
@@ -12,9 +12,7 @@ RSpec.shared_examples 'a container' do
         let(:options) { {} }
 
         before do
-          klass.configure do |config|
-            config.registry = custom_registry
-          end
+          klass.registry custom_registry
 
           allow(custom_registry).to receive(:call)
         end
@@ -22,9 +20,7 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.configure do |config|
-            config.registry = Dry::Container::Registry.new
-          end
+          klass.registry Dry::Container::Registry.new
         end
 
         subject! { container.register(key, item, options) }
@@ -42,7 +38,7 @@ RSpec.shared_examples 'a container' do
 
     describe 'resolver' do
       describe 'default' do
-        it { expect(klass.config.resolver).to be_a(Dry::Container::Resolver) }
+        it { expect(klass.resolver).to be_a(Dry::Container::Resolver) }
       end
 
       describe 'custom' do
@@ -51,9 +47,7 @@ RSpec.shared_examples 'a container' do
         let(:key) { :key }
 
         before do
-          klass.configure do |config|
-            config.resolver = custom_resolver
-          end
+          klass.resolver custom_resolver
 
           allow(custom_resolver).to receive(:call).and_return(item)
         end
@@ -61,9 +55,7 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.configure do |config|
-            config.resolver = Dry::Container::Resolver.new
-          end
+          klass.resolver Dry::Container::Resolver.new
         end
 
         subject! { container.resolve(key) }
@@ -75,7 +67,7 @@ RSpec.shared_examples 'a container' do
 
     describe 'namespace_separator' do
       describe 'default' do
-        it { expect(klass.config.namespace_separator).to eq('.') }
+        it { expect(klass.namespace_separator).to eq('.') }
       end
 
       describe 'custom' do
@@ -85,9 +77,7 @@ RSpec.shared_examples 'a container' do
         let(:namespace) { 'one' }
 
         before do
-          klass.configure do |config|
-            config.namespace_separator = namespace_separator
-          end
+          klass.namespace_separator namespace_separator
 
           container.namespace(namespace) do
             register('key', 'item')
@@ -97,9 +87,7 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.configure do |config|
-            config.namespace_separator = '.'
-          end
+          klass.namespace_separator '.'
         end
 
         subject! { container.resolve([namespace, key].join(namespace_separator)) }


### PR DESCRIPTION
While working on the new version of `dry-configurable` https://github.com/dry-rb/dry-configurable/pull/49 we decided to use `dry-struct` to store the config information, but we found that using `dry-struct` would be possible, because it will create a circular dependency: 

`dry-struct` requires `dry-types` which requires `dry-container` which require `dry-configurable` 💥 

![Dependency Graph](https://files.gitter.im/dry-rb/core-team/XnlQ/gem_graph.png)

For the issue to be resolve, we decided that the best approach would be to remove `dry-configurable` from here and use [dry-core Class Attributes](https://github.com/dry-rb/dry-core/blob/master/lib/dry/core/class_attributes.rb) to store both `registry`, `resolver` and `namespace_separator`