### PR TITLE
Allow mixing String and Symbols when stubbing

### DIFF
--- a/lib/dry/container/stub.rb
+++ b/lib/dry/container/stub.rb
@@ -5,12 +5,12 @@ module Dry
       #
       # @api public
       def resolve(key)
-        _stubs.fetch(key) { super }
+        _stubs.fetch(key.to_s) { super }
       end
 
       # Add a stub to the container
       def stub(key, value, &block)
-        _stubs[key] = value
+        _stubs[key.to_s] = value
 
         if block
           yield
@@ -23,7 +23,7 @@ module Dry
       # Remove stubbed keys from the container
       def unstub(*keys)
         keys = _stubs.keys if keys.empty?
-        keys.each { |key| _stubs.delete(key) }
+        keys.each { |key| _stubs.delete(key.to_s) }
       end
 
       # Stubs have already been enabled turning this into a noop

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -487,5 +487,12 @@ RSpec.shared_examples 'a container' do
         expect(container.resolve(:item)).to eql('item')
       end
     end
+
+    describe 'mixing Strings and Symbols' do
+      it do
+        container.stub(:item, 'stub')
+        expect(container.resolve('item')).to eql('stub')
+      end
+    end
   end
 end


### PR DESCRIPTION
I found it confusing that stubbed containers behave differently than the real containers when mixing string and symbol keys.
