### PR TITLE
yard fix

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -145,8 +145,7 @@ module Dry
       #
       # @param [Dry::Container] other
       #   The other container to merge in
-      # @param [Hash] options
-      # @option options [Symbol] :namespace
+      # @param [Symbol, nil] namespace
       #   Namespace to prefix other container items with, defaults to nil
       #
       # @return [Dry::Container::Mixin] self


### PR DESCRIPTION
Used syntax is not recognized by yard: https://app.coditsu.io/dry-rb/builds/validations/7f31395b-1b51-47fa-82d8-874ddccdb43b/offenses?q[offense_name_cont]=UnknownParameterName

This PR fixes that.