### PR TITLE
resolve items relative to namespace

### DIFF
--- a/lib/dry/container/namespace_dsl.rb
+++ b/lib/dry/container/namespace_dsl.rb
@@ -43,6 +43,10 @@ module Dry
         self
       end
 
+      def resolve(key)
+        super(namespaced(key))
+      end
+
       private
 
       def namespaced(key)

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -415,6 +415,21 @@ RSpec.shared_examples 'a container' do
           is_expected.to eq(3)
         end
       end
+
+      context 'with nesting and when block takes arguments' do
+        before do
+          container.namespace('one') do |c|
+            c.register('two', 2)
+            c.register('three', c.resolve('two'))
+          end
+        end
+
+        subject! { container.resolve('one.three') }
+
+        it 'resolves items relative to the namespace' do
+          is_expected.to eq(2)
+        end
+      end
     end
 
     describe 'import' do


### PR DESCRIPTION
With this pull request you can design your container namespaces without knowing anything about the parent namespace (like names, etc.)