### PR TITLE
Switch back to dry-configurable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-configurable', git: 'https://github.com/dry-rb/dry-configurable'
+
 group :test do
   platforms :mri do
     gem 'codeclimate-test-reporter', require: false

--- a/dry-container.gemspec
+++ b/dry-container.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_runtime_dependency 'dry-core', '~> 0.4'
+  spec.add_runtime_dependency 'dry-configurable', '~> 0.1', '>= 0.1.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/container.rb
+++ b/lib/dry/container.rb
@@ -1,5 +1,5 @@
 require 'concurrent'
-require 'dry/core/class_attributes'
+require 'dry-configurable'
 require 'dry/container/error'
 require 'dry/container/item/base'
 require 'dry/container/item/memoizable'

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'a container' do
   describe 'configuration' do
     describe 'registry' do
       describe 'default' do
-        it { expect(klass.registry).to be_a(Dry::Container::Registry) }
+        it { expect(klass.config.registry).to be_a(Dry::Container::Registry) }
       end
 
       describe 'custom' do
@@ -12,7 +12,9 @@ RSpec.shared_examples 'a container' do
         let(:options) { {} }
 
         before do
-          klass.registry custom_registry
+          klass.configure do |config|
+            config.registry = custom_registry
+          end
 
           allow(custom_registry).to receive(:call)
         end
@@ -20,7 +22,9 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.registry Dry::Container::Registry.new
+          klass.configure do |config|
+            config.registry = Dry::Container::Registry.new
+          end
         end
 
         subject! { container.register(key, item, options) }
@@ -38,7 +42,7 @@ RSpec.shared_examples 'a container' do
 
     describe 'resolver' do
       describe 'default' do
-        it { expect(klass.resolver).to be_a(Dry::Container::Resolver) }
+        it { expect(klass.config.resolver).to be_a(Dry::Container::Resolver) }
       end
 
       describe 'custom' do
@@ -47,7 +51,9 @@ RSpec.shared_examples 'a container' do
         let(:key) { :key }
 
         before do
-          klass.resolver custom_resolver
+          klass.configure do |config|
+            config.resolver = custom_resolver
+          end
 
           allow(custom_resolver).to receive(:call).and_return(item)
         end
@@ -55,7 +61,9 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.resolver Dry::Container::Resolver.new
+          klass.configure do |config|
+            config.resolver = Dry::Container::Resolver.new
+          end
         end
 
         subject! { container.resolve(key) }
@@ -67,7 +75,7 @@ RSpec.shared_examples 'a container' do
 
     describe 'namespace_separator' do
       describe 'default' do
-        it { expect(klass.namespace_separator).to eq('.') }
+        it { expect(klass.config.namespace_separator).to eq('.') }
       end
 
       describe 'custom' do
@@ -77,7 +85,9 @@ RSpec.shared_examples 'a container' do
         let(:namespace) { 'one' }
 
         before do
-          klass.namespace_separator namespace_separator
+          klass.configure do |config|
+            config.namespace_separator = namespace_separator
+          end
 
           container.namespace(namespace) do
             register('key', 'item')
@@ -87,7 +97,9 @@ RSpec.shared_examples 'a container' do
         after do
           # HACK: Have to reset the configuration so that it doesn't
           # interfere with other specs
-          klass.namespace_separator '.'
+          klass.configure do |config|
+            config.namespace_separator = '.'
+          end
         end
 
         subject! { container.resolve([namespace, key].join(namespace_separator)) }


### PR DESCRIPTION
Once we revert dry-struct-related changes in https://github.com/dry-rb/dry-configurable/pull/59 we can switch back to dry-configurable. The goal is to make the DSL block-less in https://github.com/dry-rb/dry-configurable/pull/56 and use is as a standard way of configuring dry-container and its descendants.