### PR TITLE
Memoize decorate call appropriately

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -211,9 +211,10 @@ module Dry
         end
 
         decorator = with
+        memoize = original.is_a?(Item::Memoizable)
 
         if decorator.is_a?(Class)
-          register(key, decorator.new(original.call))
+          register(key, memoize: memoize) { decorator.new(original.call) }
         else
           register(key, decorator)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# require 'pathname'
+
 if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
   require 'yaml'
   rubies = YAML.load(File.read(File.join(__dir__, '..', '.travis.yml')))['rvm']


### PR DESCRIPTION
I discovered this when working on specs for dry-system.

There are two issues IMO:

(1) `#decorate` turns a non-memoized item into, effectively, a memoized one.
(2) The original item block is called immediately, when normally it would be called at resolve time. This difference in timing could introduce subtle bugs.

The added specs cover both problems.

Edit:

I've pushed a second commit which elaborates on this fix by generalizing `#decorate`, having it take a block instead of a class (or a stub, I guess, in the second path.) The user can then do anything with the original value in that block to decorate it. More flexible.

Add'l edit:

On second thought, original fix first, then maybe feature improvement.