### PR TITLE
Alias #key? as #has_key?

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -163,6 +163,7 @@ module Dry
       def key?(key)
         config.resolver.key?(_container, key)
       end
+      alias has_key? key?
 
       # An array of registered names for the container
       #

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -318,6 +318,18 @@ RSpec.shared_examples 'a container' do
       end
     end
 
+    describe '#has_key? is alias of #key? for spec matching' do
+      let(:key) { :key }
+
+      before do
+        container.register(key) { :item }
+      end
+
+      subject! { container }
+
+      it { is_expected.to have_key(key) }
+    end
+
     describe '#keys' do
       let(:keys) { [:key_1, :key_2] }
       let(:expected_keys) { ['key_1', 'key_2'] }


### PR DESCRIPTION
It would be nice if #key? were aliased to #has_key? so that the `expect(container).to have_key(key)` RSpec matcher can be used instead of `expect(container.key?(key)).to be(true)`