### PR TITLE
Support object instance as a decorator

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -214,10 +214,14 @@ module Dry
         memoize = original.is_a?(Item::Memoizable)
 
         if decorator.is_a?(Class)
-          register(key, memoize: memoize) { decorator.new(original.call) }
+          decorated = -> { decorator.new(original.call) }
+        elsif decorator.respond_to?(:call)
+          decorated = -> { decorator.call(original.call) }
         else
-          register(key, decorator)
+          raise Error, "Decorator needs to be a Class or responds to the `call` method"
         end
+
+        register(key, memoize: memoize, &decorated)
       end
 
       # Evaluate block and register items in namespace

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -437,16 +437,20 @@ RSpec.shared_examples 'a container' do
         end
       end
 
-      context 'with instance as a decorator' do
-        let(:decorator) { double }
+      context 'with an instance as a decorator' do
+        let(:decorator) do
+          double.tap do |decorator|
+            allow(decorator).to receive(:call) { |input| "decorated #{input}" }
+          end
+        end
 
         before do
           container.register(key) { "value" }
           container.decorate(key, with: decorator)
         end
 
-        it 'expected to override the registrated key' do
-          expect(container.resolve(key)).to be(decorator)
+        it 'expected to pass original value to decorator#call method' do
+          expect(container.resolve(key)).to eq("decorated value")
         end
       end
     end

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -436,6 +436,19 @@ RSpec.shared_examples 'a container' do
           expect(container.resolve(key).__getobj__.call).to eql("value")
         end
       end
+
+      context 'with instance as a decorator' do
+        let(:decorator) { double }
+
+        before do
+          container.register(key) { "value" }
+          container.decorate(key, with: decorator)
+        end
+
+        it 'expected to override the registrated key' do
+          expect(container.resolve(key)).to be(decorator)
+        end
+      end
     end
 
     describe 'namespace' do


### PR DESCRIPTION
Since Discourse seems to be a abandoned, here is a proposal.

Release 0.7 allows to provide a decorator, but it works only if you pass a Class object. When you pass an instance it overrides the original value.
What do you think about supporting instance as a decorator and pass object being decorated to the call method of the decorator?