### PR TITLE
CI: Use 2.4.6, 2.6.3, jruby-9.2.7.0, drop 2.3.8 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.3.8
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
   - 2.6.2
   - jruby-9.2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
 rvm:
   - 2.4.6
   - 2.5.5
-  - 2.6.2
+  - 2.6.3
   - jruby-9.2.7.0
   - truffleruby
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.2
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - truffleruby
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use 2.4.6.