### PR TITLE
Add Mixin#{dup,clone} (fixes #63)

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -270,6 +270,22 @@ module Dry
       def _container
         @_container
       end
+
+      # @api public
+      def dup
+        copy = super
+        copy.instance_variable_set(:@_container, _container.dup)
+        copy
+      end
+
+      # @api public
+      def clone
+        copy = super
+        unless copy.frozen?
+          copy.instance_variable_set(:@_container, _container.dup)
+        end
+        copy
+      end
     end
   end
 end

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -616,4 +616,23 @@ RSpec.shared_examples 'a container' do
       expect(container.freeze).to be(container)
     end
   end
+
+  describe '.dup' do
+    it "returns a copy that doesn't share registered keys with the parent" do
+      container.dup.register(:foo, 'bar')
+      expect(container.key?(:foo)).to be false
+    end
+  end
+
+  describe '.clone' do
+    it "returns a copy that doesn't share registered keys with the parent" do
+      container.clone.register(:foo, 'bar')
+      expect(container.key?(:foo)).to be false
+    end
+
+    it 're-uses frozen container' do
+      expect(container.freeze.clone).to be_frozen
+      expect(container.clone._container).to be(container._container)
+    end
+  end
 end


### PR DESCRIPTION
We shoulnt't share `_container` instances across different containers, it leads to bugs and confusion.