### PR TITLE
Add fallback block to Container::Mixin#resolve

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -107,12 +107,15 @@ module Dry
       #
       # @param [Mixed] key
       #   The key for the item you wish to resolve
+      # @yield
+      #   Fallback block to call when a key is missing. Its result will be returned
+      # @yieldparam [Mixed] key Missing key
       #
       # @return [Mixed]
       #
       # @api public
-      def resolve(key)
-        config.resolver.call(_container, key)
+      def resolve(key, &block)
+        config.resolver.call(_container, key, &block)
       end
 
       # Resolve an item from the container

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -10,16 +10,24 @@ module Dry
       #   The container
       # @param [Mixed] key
       #   The key for the item you wish to resolve
+      # @yield
+      #   Fallback block to call when a key is missing. Its result will be returned
+      # @yieldparam [Mixed] key Missing key
       #
       # @raise [Dry::Conainer::Error]
-      #   If the given key is not registered with the container
+      #   If the given key is not registered with the container (and no block provided)
+      #
       #
       # @return [Mixed]
       #
       # @api public
       def call(container, key)
         item = container.fetch(key.to_s) do
-          raise Error, "Nothing registered with the key #{key.inspect}"
+          if block_given?
+            return yield(key)
+          else
+            raise Error, "Nothing registered with the key #{key.inspect}"
+          end
         end
 
         item.call

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -635,4 +635,10 @@ RSpec.shared_examples 'a container' do
       expect(container.clone._container).to be(container._container)
     end
   end
+
+  describe '.resolve' do
+    it 'accepts a fallback block' do
+      expect(container.resolve('missing') { :fallback }).to be(:fallback)
+    end
+  end
 end


### PR DESCRIPTION
Similar to Hash#fetch

```ruby
container.resolve('missing') { :default } # => :default
```