### PR TITLE
Support for decorating static values

### DIFF
--- a/lib/dry/container/item.rb
+++ b/lib/dry/container/item.rb
@@ -23,6 +23,27 @@ module Dry
       def call
         raise NotImplementedError
       end
+
+      # @private
+      def value?
+        !callable?
+      end
+
+      # @private
+      def callable?
+        options[:call]
+      end
+
+      # Build a new item with transformation applied
+      #
+      # @private
+      def map(func)
+        if callable?
+          self.class.new(-> { func.(item.call) }, options)
+        else
+          self.class.new(func.(item), options)
+        end
+      end
     end
   end
 end

--- a/lib/dry/container/item/callable.rb
+++ b/lib/dry/container/item/callable.rb
@@ -14,13 +14,6 @@ module Dry
         def call
           callable? ? item.call : item
         end
-
-        private
-
-        # @private
-        def callable?
-          options[:call]
-        end
       end
     end
   end

--- a/lib/dry/container/item/memoizable.rb
+++ b/lib/dry/container/item/memoizable.rb
@@ -21,7 +21,7 @@ module Dry
         # @return [Dry::Container::Item::Base]
         def initialize(item, options = {})
           super
-          raise_not_supported_error unless item.is_a?(::Proc)
+          raise_not_supported_error unless callable?
 
           @memoize_mutex = ::Mutex.new
         end


### PR DESCRIPTION
This also adds support for block decorators:
```ruby
container.decorate('operation') do |op|
  Wrapper.new(op)
end
```