### PR TITLE
[doc] Clean up example code

### DIFF
--- a/docsite/source/registry-and-resolver.html.md
+++ b/docsite/source/registry-and-resolver.html.md
@@ -63,14 +63,7 @@ class Container
   extend Dry::Container::Mixin
 
   config.registry = ->(container, key, item, options) { container[key] = item }
-  config.resolver = CustomResolver
-end
-
-class ContainerObject
-  include Dry::Container::Mixin
-
-  config.registry = ->(container, key, item, options) { container[key] = item }
-  config.resolver = CustomResolver
+  config.resolver = CustomResolver.new
 end
 ```
 


### PR DESCRIPTION
Code is duplicated with no clear reason.

`.new` is forgotten on `config.resolver` assignment.