### PR TITLE
Docs: Add an example unstubbing all keys at once

### DIFF
--- a/docsite/source/testing.html.md
+++ b/docsite/source/testing.html.md
@@ -37,3 +37,21 @@ container[:redis] # => "Stubbed redis instance"
 
 container.unstub(:redis) # => "Redis instance"
 ```
+
+To clear all stubs at once, call `#unstub` without any arguments:
+
+```ruby
+container = Dry::Container.new
+container.register(:redis) { "Redis instance" }
+container.register(:db) { "DB instance" }
+
+require 'dry/container/stub'
+container.enable_stubs!
+container.stub(:redis, "Stubbed redis instance")
+container.stub(:db, "Stubbed DB instance")
+
+container.unstub # This will unstub all previously stubbed keys
+
+container[:redis] # => "Redis instance"
+container[:db] # => "Redis instance"
+```


### PR DESCRIPTION
I was looking for this behavior this morning and couldn't find it in the docs. I figured it might be helpful for others too.