### PR TITLE
Wrap FrozenError, to state that the container itself is frozen

### DIFF
--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -106,7 +106,7 @@ module Dry
 
         self
       rescue FrozenError
-        raise FrozenError, "can't modify frozen Dry::Container (when attempting to register '#{key}')"
+        raise FrozenError, "can't modify frozen #{self.class} (when attempting to register '#{key}')"
       end
 
       # Resolve an item from the container

--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -105,6 +105,8 @@ module Dry
         config.registry.call(_container, key, item, options)
 
         self
+      rescue FrozenError
+        raise FrozenError, "can't modify frozen Dry::Container (when attempting to register '#{key}')"
       end
 
       # Resolve an item from the container

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -636,7 +636,10 @@ RSpec.shared_examples "a container" do
     it "wraps FrozenError to provide which key was attempted to be registered" do
       container.freeze
       expect { container.register(:baz, "quux") }
-        .to raise_error(FrozenError, "can't modify frozen Dry::Container (when attempting to register 'baz')")
+        .to raise_error(
+          FrozenError,
+          /can't modify frozen \S+ \(when attempting to register 'baz'\)/
+        )
     end
 
     it "returns self back" do

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -633,6 +633,12 @@ RSpec.shared_examples "a container" do
       expect(container).to be_frozen
     end
 
+    it "wraps FrozenError to provide which key was attempted to be registered" do
+      container.freeze
+      expect { container.register(:baz, "quux") }
+        .to raise_error(FrozenError, "can't modify frozen Dry::Container (when attempting to register 'baz')")
+    end
+
     it "returns self back" do
       expect(container.freeze).to be(container)
     end


### PR DESCRIPTION
Before:
```
FrozenError: 
  can't modify frozen Concurrent::Hash: {"foo"=>#<Dry::Container::Item::Callable:0x00007f9a9f2eaea0 @item="bar", @options={:call=>false}>}
```

After:
```
FrozenError:
  can't modify frozen Dry::Container (when attempting to register 'baz')
```

That a `Dry::Container` is implemented with `Concurrent::Hash` is an implemention detail. I think wrapping it helps users of the library see that this is an expected exception, rather than an error within the library. And the text in the parentheses should help users when they encounter this error.

I also split up the specs and removed a conditional for whether Ruby is 2.5+, since this gem only supports 2.5+ now.

(Relevant commit where `.freeze` was implemented: https://github.com/dry-rb/dry-container/commit/6fc5cd2650b1888ac6f4fc56592878695d296979)