### PR TITLE
Raise KeyError for missing key, with DidYouMean integration

### DIFF
--- a/lib/dry/container/error.rb
+++ b/lib/dry/container/error.rb
@@ -4,5 +4,10 @@ module Dry
   class Container
     # @api public
     Error = Class.new(StandardError)
+
+    KeyError = Class.new(::KeyError)
+    DidYouMean.correct_error(KeyError, DidYouMean::KeyErrorChecker)
+
+    deprecate_constant(:Error)
   end
 end

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -16,7 +16,7 @@ module Dry
       #   Fallback block to call when a key is missing. Its result will be returned
       # @yieldparam [Mixed] key Missing key
       #
-      # @raise [Dry::Container::Error]
+      # @raise [KeyError]
       #   If the given key is not registered with the container (and no block provided)
       #
       #
@@ -28,7 +28,7 @@ module Dry
           if block_given?
             return yield(key)
           else
-            raise Error, "Nothing registered with the key #{key.inspect}"
+            raise KeyError.new(key: key.to_s, receiver: container)
           end
         end
 

--- a/lib/dry/container/resolver.rb
+++ b/lib/dry/container/resolver.rb
@@ -28,7 +28,7 @@ module Dry
           if block_given?
             return yield(key)
           else
-            raise KeyError.new(key: key.to_s, receiver: container)
+            raise KeyError.new(%(key not found: "#{key}"), key: key.to_s, receiver: container)
           end
         end
 

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -253,7 +253,12 @@ RSpec.shared_examples "a container" do
     describe "resolving with a key that has not been registered" do
       it do
         expect(container.key?(:item)).to be false
-        expect { container.resolve(:item) }.to raise_error(Dry::Container::Error)
+        expect { container.resolve(:item) }.to raise_error(KeyError) do |error|
+          # This is the API needed for DidYouMean::KeyErrorChecker to provide corrections
+          expect(error.key).to eq("item")
+          expect(error.receiver).to eq(container._container)
+          expect(error.spell_checker).to be_instance_of(DidYouMean::KeyErrorChecker)
+        end
       end
     end
 


### PR DESCRIPTION
We could go further to check to make sure actual suggestions are offered, but that's like testing the external library. The last spec example, the instance check, is actually enough (without checking `key` and `provider`), but it'll raise an error without the other two values set, so we might as well check those first.

I think we'll want to extract some proper `Dry::Container::Error`s, possibly our own `Dry::Container::KeyError` but these specs will ensure we don't regress this neat functionality that Ruby gives us

After this PR:
```ruby
> require 'dry/container'
> c = Dry::Container.new
> c.register(:foo, 3)
> c[:floof]
# KeyError: KeyError
# Did you mean?  "foo"
```