### PR TITLE
Replace dep on dry-configurable with a simple Configuration mod

### DIFF
--- a/dry-container.gemspec
+++ b/dry-container.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
 
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 0.13", ">= 0.13.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/dry/container.rb
+++ b/lib/dry/container.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "dry-configurable"
 require "dry/container/error"
 require "dry/container/namespace"
 require "dry/container/registry"

--- a/project.yml
+++ b/project.yml
@@ -10,4 +10,3 @@ gemspec:
     - rspec
   runtime_dependencies:
     - [concurrent-ruby, "~> 1.0"]
-    - [dry-configurable, "~> 0.13", ">= 0.13.0"]


### PR DESCRIPTION
This removes dependency on dry-configurable as dry-container is a lower-level gem and it shouldn't depend on dry-configurable, which is a higher-level gem. Originally, this wasn't the case, but dry-configurable has grown into a quite advanced configuration system (and will most likely continue to evolve).

Configuration needs of dry-container are very basic, they don't justify the usage of dry-configurable. Notice that dry-container is one of the oldest dry-rb gems and throughout the years its config (3 config values: namespace separator, registry and resolver) have been always the same.

Stuff works the same now:

```ruby
irb(main):001:1* class MyContainer
irb(main):002:1*   include Dry::Container::Mixin
irb(main):003:0> end
=> MyContainer
irb(main):004:0> MyContainer.config.namespace_separator = "/"
=> "/"
irb(main):005:0> mc = MyContainer.new
=> #<MyContainer:0x00007f9a68962a30 @_container={}>
irb(main):006:0> mc.namespace("foo") { |foo| foo.register("bar", :bar) }
=> #<MyContainer:0x00007f9a68962a30 @_container={"foo/bar"=>#<Dry::Container::Item::Callable:0x00007f9a689df990 @item=:bar, @options={:call=>false}>}>
irb(main):007:0> mc["foo/bar"]
=> :bar
```