### PR TITLE
Use dry/configurable if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-        - "3.1"
-        - "3.0"
-        - "2.7"
+          - "3.1"
+          - "3.0"
+          - "2.7"
         include:
           - ruby: "3.1"
             coverage: "true"
@@ -47,6 +47,8 @@ jobs:
           bundler-cache: true
       - name: Run all tests
         run: bundle exec rake
+      - name: Run all tests using dry/configurable for config
+        run: bundle exec rake spec:configurable
   release:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags') && github.event_name == 'create'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "dry-configurable"
+
 group :tools do
   gem "pry-byebug", platform: :mri
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,9 @@ task default: :spec
 
 desc "Run all specs in spec directory"
 RSpec::Core::RakeTask.new(:spec)
+
+desc "Run specs with dry/configurable loaded"
+task "spec:configurable" do
+  ENV["DRY_CONFIGURABLE"] = "true"
+  Rake::Task["spec"].invoke
+end

--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -33,12 +33,27 @@ module Dry
 
     # @api public
     module Configuration
-      # @api public
-      def config
-        @config ||= Config.new
+      # Use dry/configurable if it's available
+      if defined?(Configurable)
+        # @api private
+        def self.extended(klass)
+          super
+          klass.class_eval do
+            extend Dry::Configurable
+
+            setting :namespace_separator, default: Config::DEFAULT_NAMESPACE_SEPARATOR
+            setting :resolver, default: Config::DEFAULT_RESOLVER
+            setting :registry, default: Config::DEFAULT_REGISTRY
+          end
+        end
+      else
+        # @api private
+        def config
+          @config ||= Config.new
+        end
       end
 
-      # @api public
+      # @api private
       def configure
         yield config
       end
@@ -71,9 +86,7 @@ module Dry
     #   container.resolve(:item)
     #   => 'item'
     #
-    #
     # @api public
-    # rubocop: disable Metrics/ModuleLength
     module Mixin
       # @private
       def self.extended(base)

--- a/spec/integration/mixin_spec.rb
+++ b/spec/integration/mixin_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe Dry::Container::Mixin do
     let(:klass) do
       Class.new { extend Dry::Container::Mixin }
     end
-    let(:container) { klass }
+
+    let(:container) do
+      klass
+    end
 
     it_behaves_like "a container"
   end
@@ -14,20 +17,70 @@ RSpec.describe Dry::Container::Mixin do
     let(:klass) do
       Class.new { include Dry::Container::Mixin }
     end
-    let(:container) { klass.new }
+
+    let(:container) do
+      klass.new
+    end
 
     it_behaves_like "a container"
 
     context "into a class with a custom .initialize method" do
       let(:klass) do
         Class.new do
+          attr_reader :test
+
           include Dry::Container::Mixin
-          def initialize; end
+
+          def initialize
+            @test = true
+          end
         end
       end
 
       it "does not fail on missing member variable" do
         expect { container.register :key, -> {} }.to_not raise_error
+      end
+
+      it "doesn't override the original initialize method" do
+        expect(container.test).to be(true)
+      end
+    end
+  end
+
+  if defined?(Dry::Configurable)
+    context "using custom settings via Dry::Configurable with a class" do
+      let(:klass) do
+        Class.new do
+          extend Dry::Container::Mixin
+
+          setting :root, default: "/tmp"
+        end
+      end
+
+      let(:container) do
+        klass
+      end
+
+      it "exposes custom config" do
+        expect(container.config.root).to eql("/tmp")
+      end
+    end
+
+    context "using custom settings via Dry::Configurable with an object" do
+      let(:klass) do
+        Class.new do
+          include Dry::Container::Mixin
+
+          setting :root, default: "/tmp"
+        end
+      end
+
+      let(:container) do
+        klass.new
+      end
+
+      it "exposes custom config" do
+        expect(container.config.root).to eql("/tmp")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@ Dir[Pathname(__FILE__).dirname.join("support/**/*.rb").to_s].sort.each do |file|
   require file
 end
 
+if ENV["DRY_CONFIGURABLE"] == "true"
+  require "dry/configurable"
+end
+
 require "dry/container"
 require "dry/container/stub"
 


### PR DESCRIPTION
This is a quick follow up after #84 because it may be a common situation when dry/configurable API is provided by the class that includes dry/container, in such case we should rely on it as otherwise there would be a conflict.