### PR TITLE
Make `DidYouMean` integration optional

### DIFF
--- a/lib/dry/container/error.rb
+++ b/lib/dry/container/error.rb
@@ -6,7 +6,9 @@ module Dry
     Error = Class.new(StandardError)
 
     KeyError = Class.new(::KeyError)
-    DidYouMean.correct_error(KeyError, DidYouMean::KeyErrorChecker)
+    if defined?(DidYouMean::KeyErrorChecker)
+      DidYouMean.correct_error(KeyError, DidYouMean::KeyErrorChecker)
+    end
 
     deprecate_constant(:Error)
   end


### PR DESCRIPTION
The gem won't load when DidYouMean is disabled with
--disable-did_you_mean:

```
RUBYOPT='--disable-did_you_mean' rake
[...]
NameError:
  uninitialized constant Dry::Container::DidYouMean
# ./lib/dry/container/error.rb:9:in `<class:Container>'
```

With this commit, the gem loads even though some tests fail.

-----

We run some of our Ruby apps with `--disable-did_you_mean` for performance reasons, hence the change. 

I didn't write any tests for this. The only test I could think of would be something like shelling out to load a new Ruby interpreter without `DidYouMean` and validating that it doesn't fail:
```
ruby --disable-did_you_mean -r "dry-container" -e ""
```

I didn't see a lot of value in such test, but open to feedback or alternative.