### PR TITLE
Update shim to match dry-configurable’s configure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
-gem "dry-configurable"
+# gem "dry-configurable"
+gem "dry-configurable", github: "dry-rb/dry-configurable", branch: "write-settings-in-configure-only"
+gem "dry-core", github: "dry-rb/dry-core"
 
 group :tools do
   gem "pry-byebug", platform: :mri

--- a/lib/dry/container/mixin.rb
+++ b/lib/dry/container/mixin.rb
@@ -11,13 +11,13 @@ module Dry
       DEFAULT_REGISTRY = Registry.new
 
       # @api public
-      attr_accessor :namespace_separator
+      attr_reader :namespace_separator
 
       # @api public
-      attr_accessor :resolver
+      attr_reader :resolver
 
       # @api public
-      attr_accessor :registry
+      attr_reader :registry
 
       # @api private
       def initialize(
@@ -28,6 +28,35 @@ module Dry
         @namespace_separator = namespace_separator
         @resolver = resolver
         @registry = registry
+      end
+
+      # @api private
+      def to_configure
+        Mutable.new(
+          namespace_separator: namespace_separator,
+          resolver: resolver,
+          registry: registry
+        )
+      end
+
+      # @api private
+      def update(config)
+        @namespace_separator = config.namespace_separator
+        @resolver = config.resolver
+        @registry = config.registry
+
+        self
+      end
+
+      class Mutable < Config
+        # @api public
+        attr_accessor :namespace_separator
+
+        # @api public
+        attr_accessor :resolver
+
+        # @api public
+        attr_accessor :registry
       end
     end
 
@@ -53,11 +82,13 @@ module Dry
         def config
           @config ||= Config.new
         end
-      end
 
-      # @api private
-      def configure
-        yield config
+        # @api private
+        def configure
+          configured = config.to_configure
+          yield configured
+          config.update(configured)
+        end
       end
     end
 


### PR DESCRIPTION
Now we require config to be updated inside `configure` blocks only.

This matches the behaviour that we're introducing in https://github.com/dry-rb/dry-configurable/pull/140.