### PR TITLE
Fixed error in custom resolver documentaion.

### DIFF
--- a/docsite/source/registry-and-resolver.html.md
+++ b/docsite/source/registry-and-resolver.html.md
@@ -44,7 +44,7 @@ You can configure how items are registered and resolved from the container. Curr
 but custom resolver should subclass the default one or have the same public interface.
 
 ```ruby
-class CustomResolver < Dry::Container::Registry
+class CustomResolver < Dry::Container::Resolver
   RENAMED_KEYS = { 'old' => 'new' }
 
   def call(container, key)


### PR DESCRIPTION
There seems to be an error in the custom resolver documentaion where the CustomResolver example class inherits from Dry::Container::Registry instead of Dry::Container::Resolver, so updated the markdown in docsite to fix this.